### PR TITLE
A script for breaking up WGS data into smaller intervals at N strings

### DIFF
--- a/HelperScripts/Intervals_at_Ns.sh
+++ b/HelperScripts/Intervals_at_Ns.sh
@@ -1,3 +1,12 @@
+#PBS -S /bin/bash
+#PBS -q batch
+#PBS -N Intervals_at_Ns
+#PBS -l nodes=1:ppn=6
+#PBS -l walltime=4:00:00
+#PBS -l mem=22gb
+#PBS -M dittmare@gmail.com
+#PBS -m abe
+
 ### A script to break up WGS data into Intervals at N-strings
 ### E. Dittmar February 2020
 
@@ -40,19 +49,19 @@ REF_FASTA=/scratch/eld72413/Ha412HOv2.0/Ha412HOv2.0-20181130.fasta
 INPUT_INTERVALS=/scratch/eld72413/SAM_seq/results2/VCF_results/intervals2.list
 
 # Where do you want output files?
-OUTPUTDIR=/scratch/eld72413/SAM_seq/results2/VCF_results_new/ScriptTest/New
+OUTPUTDIR=/scratch/eld72413/SAM_seq/results2/VCF_results_new/N_Intervals
 
 #	Minimum number of "N's" which will be used for scattering intervals
 NUM_Ns_TOL=3000
 
-#	Approximately how large do you want intervals to be?
+#	Approximately how large do you want intervals to be (in bp)?
 INT_SIZE=20000000
 
 #	Specify a temporary directory
-TEMP_DIR=/scratch/eld72413/SAM_seq/results2/VCF_results_new/N_Intervals/Int_Test
+TEMP_DIR=/scratch/eld72413/SAM_seq/results2/VCF_results_new/N_Intervals
 
 # Name for final output .bed file (no .bed extension here)
-OUT_NAME=N_List_test
+OUT_NAME=INTERVALS_20k_atNs
 
 
 ####################################
@@ -95,7 +104,7 @@ awk -v OFS='\t' {'print $1,$2'} "${OUTPUTDIR}/Input_Intervals.fasta.fai" > "${OU
 
 #3. Make Intervals file with regularly sized intervals for each chromosome/region
 
-echo "Breaking up genome over N-strings that are approximately ${INT_SIZE} in size"
+echo "Breaking up genome over N-strings that are approximately ${INT_SIZE} bp in size"
 
 bedtools makewindows \
 -g "${OUTPUTDIR}/Input_Intervals_genomeFile.txt" \
@@ -103,7 +112,7 @@ bedtools makewindows \
 
 bedtools intersect -wo -sorted -F 0.5 \
 -a stdin \
--b "${OUTPUTDIR}/N_sep_intervals.bed" | \
+-b "${OUTPUTDIR}/N_${NUM_Ns_TOL}_sep_intervals.bed" | \
 
 bedtools groupby -i stdin \
 -g 1,2 -c 5,6 -o min,max | \

--- a/HelperScripts/Intervals_at_Ns.sh
+++ b/HelperScripts/Intervals_at_Ns.sh
@@ -1,0 +1,122 @@
+### A script to break up WGS data into Intervals at N-strings
+### E. Dittmar February 2020
+
+### The following script takes in as input:
+### 1.) Reference FASTA
+### 2.) List of genomic regions to use (e.g chromosome names)
+
+### And Outputs:
+### 1.) A new FASTA file with only the sequence specified by the input list + corresponding index and dictionary files
+### 2.) Both interval and BED files with the interval coordinates of N strings above the minimum number specified
+###	3.) A genome file for use with Bedtools functions
+### 4.) A final .bed file with intervals that are of the approximate size specified and broken up at strings of N's
+
+####################################
+########### DEPENDENCIES ###########
+####################################
+
+### Requires GATK (including jar filepath), Picard (including jar filepath), and Bedtools
+
+#   What is the full file path for the GATK jar file?
+module load GATK/4.1.2.0-GCCcore-8.2.0-Java-1.8
+GATK_JAR=/usr/local/apps/eb/GATK/4.1.2.0-GCCcore-8.2.0-Java-1.8/gatk
+
+#   What is the full file path for the Picard jar file?
+module load picard/2.16.0-Java-1.8.0_144
+PICARD_JAR=/usr/local/apps/eb/picard/2.16.0-Java-1.8.0_144/picard.jar
+
+module load BEDTools/2.29.2-GCC-8.2.0-2.31.1
+
+
+####################################
+##### USER-SUPPLIED VARIABLES ######
+####################################
+
+# Reference FASTA sequence
+REF_FASTA=/scratch/eld72413/Ha412HOv2.0/Ha412HOv2.0-20181130.fasta
+
+# List of Genomic Regions to make intervals from
+# Names must match names in REF_FASTA
+INPUT_INTERVALS=/scratch/eld72413/SAM_seq/results2/VCF_results/intervals2.list
+
+# Where do you want output files?
+OUTPUTDIR=/scratch/eld72413/SAM_seq/results2/VCF_results_new/ScriptTest/New
+
+#	Minimum number of "N's" which will be used for scattering intervals
+NUM_Ns_TOL=3000
+
+#	Approximately how large do you want intervals to be?
+INT_SIZE=20000000
+
+#	Specify a temporary directory
+TEMP_DIR=/scratch/eld72413/SAM_seq/results2/VCF_results_new/N_Intervals/Int_Test
+
+# Name for final output .bed file (no .bed extension here)
+OUT_NAME=N_List_test
+
+
+####################################
+## CODE FOR INTERVALS FILE AT N's ##
+####################################
+
+set -o pipefail
+
+#1. Use GATK to find regions with N's
+
+# First, make new FASTA file with interval subset
+# This automatically creates an index and dictionary which is required by "ScatterIntervalsByNs"
+echo "Writing FASTA files for input intervals"
+ gatk FastaReferenceMaker \
+   -R "$REF_FASTA" \
+   -O "$OUTPUTDIR/Input_Intervals.fasta" \
+   -L "${INPUT_INTERVALS}"
+
+# Then make intervals file showing N-strings + remaining "ACGT" intervals
+echo "Finding genomic coordinates for N-strings greater than ${NUM_Ns_TOL}"
+java -jar ${PICARD_JAR} ScatterIntervalsByNs \
+    R="${OUTPUTDIR}/Input_Intervals.fasta" \
+    OT=BOTH \
+    OUTPUT="${OUTPUTDIR}/N_${NUM_Ns_TOL}_sep.interval_list" \
+    N="${NUM_Ns_TOL}"
+
+# Then convert to BED file format
+echo "Converting N-sep list to BED format"
+java -jar ${PICARD_JAR} IntervalListToBed \
+	I="${OUTPUTDIR}/N_${NUM_Ns_TOL}_sep.interval_list" \
+	O="${OUTPUTDIR}/N_${NUM_Ns_TOL}_sep_intervals.bed" \
+	TMP_DIR="${TEMP_DIR}"
+
+
+#2. Make a Genome file
+
+echo "Making Genome File"
+awk -v OFS='\t' {'print $1,$2'} "${OUTPUTDIR}/Input_Intervals.fasta.fai" > "${OUTPUTDIR}/Input_Intervals_genomeFile.txt"
+
+
+#3. Make Intervals file with regularly sized intervals for each chromosome/region
+
+echo "Breaking up genome over N-strings that are approximately ${INT_SIZE} in size"
+
+bedtools makewindows \
+-g "${OUTPUTDIR}/Input_Intervals_genomeFile.txt" \
+-w $INT_SIZE | \
+
+bedtools intersect -wo -sorted -F 0.5 \
+-a stdin \
+-b "${OUTPUTDIR}/N_sep_intervals.bed" | \
+
+bedtools groupby -i stdin \
+-g 1,2 -c 5,6 -o min,max | \
+
+awk -v OFS='\t' {'print $1,$3,$4'} > "${OUTPUTDIR}/${OUT_NAME}.bed"
+
+# Replace chromosome names with their original names from the "Input_Intervals" file
+# For some reason, FASTA reference maker changes the chromosome names to numbers based on the order of the intervals
+# Here the names are changed back
+
+for i in $(cat $INPUT_INTERVALS); do
+  oldvar=$(sed -n "/${i}/=" $INPUT_INTERVALS)
+  echo "Replacing chromosome name $oldvar to $i"
+  sed -i 's/'^"${oldvar}"'\b/'"${i}"'/g' "${OUTPUTDIR}/${OUT_NAME}.bed"
+done
+

--- a/HelperScripts/Intervals_at_Ns.sh
+++ b/HelperScripts/Intervals_at_Ns.sh
@@ -4,7 +4,7 @@
 #PBS -l nodes=1:ppn=6
 #PBS -l walltime=4:00:00
 #PBS -l mem=22gb
-#PBS -M dittmare@gmail.com
+#PBS -M 
 #PBS -m abe
 
 ### A script to break up WGS data into Intervals at N-strings
@@ -12,19 +12,21 @@
 
 ### The following script takes in as input:
 ### 1.) Reference FASTA
-### 2.) List of genomic regions to use (e.g chromosome names)
+### 2.) List of genomic regions to break into smaller intervals (e.g chromosome names)
 
 ### And Outputs:
 ### 1.) A new FASTA file with only the sequence specified by the input list + corresponding index and dictionary files
 ### 2.) Both interval and BED files with the interval coordinates of N strings above the minimum number specified
 ###	3.) A genome file for use with Bedtools functions
-### 4.) A final .bed file with intervals that are of the approximate size specified and broken up at strings of N's
+### 4.) A final .bed file with intervals that are of the approximate size specified and broken up at strings of N's. 
+      # This file can be put directly into the CUSTOM_INTERVALS variable of your config to run Genomics_DB_Import and Genotype_GVCFs
 
 ####################################
 ########### DEPENDENCIES ###########
 ####################################
 
 ### Requires GATK (including jar filepath), Picard (including jar filepath), and Bedtools
+### Replace with correct installation paths
 
 #   What is the full file path for the GATK jar file?
 module load GATK/4.1.2.0-GCCcore-8.2.0-Java-1.8
@@ -35,33 +37,36 @@ module load picard/2.16.0-Java-1.8.0_144
 PICARD_JAR=/usr/local/apps/eb/picard/2.16.0-Java-1.8.0_144/picard.jar
 
 module load BEDTools/2.29.2-GCC-8.2.0-2.31.1
-
+#BEDTOOLS=
+#export PATH=${BEDTOOLS}:${PATH}
 
 ####################################
 ##### USER-SUPPLIED VARIABLES ######
 ####################################
 
-# Reference FASTA sequence
-REF_FASTA=/scratch/eld72413/Ha412HOv2.0/Ha412HOv2.0-20181130.fasta
+### Include full filepaths for all files
+
+# Reference FASTA file
+REF_FASTA=
 
 # List of Genomic Regions to make intervals from
 # Names must match names in REF_FASTA
-INPUT_INTERVALS=/scratch/eld72413/SAM_seq/results2/VCF_results/intervals2.list
+INPUT_INTERVALS=
 
 # Where do you want output files?
-OUTPUTDIR=/scratch/eld72413/SAM_seq/results2/VCF_results_new/N_Intervals
+OUTPUTDIR=
 
 #	Minimum number of "N's" which will be used for scattering intervals
-NUM_Ns_TOL=3000
+NUM_Ns_TOL=500
 
 #	Approximately how large do you want intervals to be (in bp)?
-INT_SIZE=20000000
+INT_SIZE=10000000
 
 #	Specify a temporary directory
-TEMP_DIR=/scratch/eld72413/SAM_seq/results2/VCF_results_new/N_Intervals
+TEMP_DIR=
 
 # Name for final output .bed file (no .bed extension here)
-OUT_NAME=INTERVALS_20k_atNs
+OUT_NAME=
 
 
 ####################################
@@ -72,8 +77,8 @@ set -o pipefail
 
 #1. Use GATK to find regions with N's
 
-# First, make new FASTA file with interval subset
-# This automatically creates an index and dictionary which is required by "ScatterIntervalsByNs"
+# First, make new FASTA file with the subset of genomic regions specified in INPUT_INTERVALS
+# This automatically creates index and dictionary files which are also required by "ScatterIntervalsByNs"
 echo "Writing FASTA files for input intervals"
  gatk FastaReferenceMaker \
    -R "$REF_FASTA" \
@@ -102,9 +107,9 @@ echo "Making Genome File"
 awk -v OFS='\t' {'print $1,$2'} "${OUTPUTDIR}/Input_Intervals.fasta.fai" > "${OUTPUTDIR}/Input_Intervals_genomeFile.txt"
 
 
-#3. Make Intervals file with regularly sized intervals for each chromosome/region
+#3. Make Intervals file with smaller-sized intervals for each chromosome/region broken up at N's
 
-echo "Breaking up genome over N-strings that are approximately ${INT_SIZE} bp in size"
+echo "Breaking up genome at N-strings into regions that are approximately ${INT_SIZE} bp in size"
 
 bedtools makewindows \
 -g "${OUTPUTDIR}/Input_Intervals_genomeFile.txt" \
@@ -120,7 +125,7 @@ bedtools groupby -i stdin \
 awk -v OFS='\t' {'print $1,$3,$4'} > "${OUTPUTDIR}/${OUT_NAME}.bed"
 
 # Replace chromosome names with their original names from the "Input_Intervals" file
-# For some reason, FASTA reference maker changes the chromosome names to numbers based on the order of the intervals
+# For some reason, GATK's FASTA reference maker changes the chromosome names to numbers based on their order
 # Here the names are changed back
 
 for i in $(cat $INPUT_INTERVALS); do


### PR DESCRIPTION
Uses GATK, Picard, and BEDTools to:
1.) Make a FASTA subset for regions of interest with corresponding .dict and .fai files
2.) Identify positions of N-strings above a user-specified threshold (returns coordinates for ACGTmers and Nmers)
3.) Convert .interval_list file to .bed file
4.) Merge regions into windows of an approximate (user-specified)  size
5.) Format for use in pipeline as a .bed file